### PR TITLE
More cookbook metadata fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To check Chef cookbook version bumps, use the `chef-cookbook-version` hook. Each
 To unit test Ruby changes in your repo, use the `rspec` hook. Each path in your repo with a `spec` directory should have a `Gemfile` that includes your desired version of rspec (or a derivative library). It will be installed via Bundler prior to testing. Rspec will only be run against the closest directory in a changed file's path with a spec dir.
 
     - repo: https://github.com/mattlqx/pre-commit-ruby
-      rev: v1.2.3
+      rev: v1.2.4
       hooks:
       - id: rubocop
       - id: foodcritic

--- a/bin/cookbook-wrapper.rb
+++ b/bin/cookbook-wrapper.rb
@@ -107,6 +107,8 @@ changed_cookbooks.each do |cb_data|
 
   if old_metadata.empty?
     puts "#{cookbook} does not have a metadata file in git history. Skipping."
+  elsif !old_metadata.data.key?(:version)
+    puts "#{cookbook} did not previously have a version. Skipping."
   elsif new_metadata['version'] == old_metadata['version']
     puts "#{cookbook} has changed and has not been version bumped."
     success = false

--- a/bin/cookbook-wrapper.rb
+++ b/bin/cookbook-wrapper.rb
@@ -35,7 +35,7 @@ end
 def higher?(old_version, new_version)
   old_version = old_version.split('.')
   new_version.split('.').each_with_index do |n, idx|
-    break true if n > old_version[idx]
+    break true if n.to_i > old_version[idx].to_i
   end == true
 end
 

--- a/bin/cookbook-wrapper.rb
+++ b/bin/cookbook-wrapper.rb
@@ -39,11 +39,8 @@ def higher?(old_version, new_version)
   end == true
 end
 
-def file_from_git_history(branch, path)
+def file_from_git_history(path)
   prefix = path.start_with?('/') ? '' : './'
-  from_branch = IO.popen("git show origin/#{branch}:#{prefix}#{path}", err: :close, &:read)
-  return from_branch unless from_branch == ''
-
   IO.popen("git show origin/master:#{prefix}#{path}", err: :close, &:read)
 end
 
@@ -96,16 +93,15 @@ end
 exit(success) if changed_cookbooks.empty?
 
 IO.popen('git fetch origin') { |_f| true }
-branch = IO.popen('git symbolic-ref --short HEAD', &:read).chomp
 changed_cookbooks.each do |cb_data|
   cookbook = cb_data[0]
   type = cb_data[1]
 
   if type == 'rb'
-    old_metadata = MetadataReader.new(file_from_git_history(branch, "#{cookbook}/metadata.rb"), "#{cookbook}/metadata.rb") # rubocop:disable Metrics/LineLength
+    old_metadata = MetadataReader.new(file_from_git_history("#{cookbook}/metadata.rb"), "#{cookbook}/metadata.rb") # rubocop:disable Metrics/LineLength
     new_metadata = MetadataReader.new(IO.read("#{cookbook}/metadata.rb"), "#{cookbook}/metadata.rb")
   else
-    old_metadata = JSON.parse(file_from_git_history(branch, "#{cookbook}/metadata.json")) rescue {} # rubocop:disable Style/RescueModifier, Metrics/LineLength
+    old_metadata = JSON.parse(file_from_git_history("#{cookbook}/metadata.json")) rescue {} # rubocop:disable Style/RescueModifier, Metrics/LineLength
     new_metadata = JSON.parse(IO.read("#{cookbook}/metadata.json"))
   end
 


### PR DESCRIPTION
Fixes some more cases I've found in use. Basically, only compare old version from master on origin, fix comparisons and handle case of metadata not having a version (like in test cookbooks).