### PR TITLE
Minor fixes to prevent cookstyle running on too large of scope

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -34,8 +34,9 @@
   entry: bin/cookstyle-wrapper.rb
   language: script
   pass_filenames: true
-  types: ['file']
+  types: ['ruby']
   verbose: true
+  require_serial: true
 - id: chef-cookbook-version
   name: Ensure Chef cookbook version bump
   description: Ensure Chef cookbook versions are bumped when contents are changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To check Chef cookbook version bumps, use the `chef-cookbook-version` hook. Each
 To unit test Ruby changes in your repo, use the `rspec` hook. Each path in your repo with a `spec` directory should have a `Gemfile` that includes your desired version of rspec (or a derivative library). It will be installed via Bundler prior to testing. Rspec will only be run against the closest directory in a changed file's path with a spec dir.
 
     - repo: https://github.com/mattlqx/pre-commit-ruby
-      rev: v1.3.0
+      rev: v1.3.1
       hooks:
       - id: rubocop
       - id: foodcritic

--- a/bin/common.rb
+++ b/bin/common.rb
@@ -28,9 +28,10 @@ def bump_required?(file)
   end == true
 end
 
-def changed_cookbooks(bump_check: true)
+def changed_cookbooks(paths = nil, bump_check: true)
   changed_cookbooks = []
-  ARGV.each do |file|
+  paths ||= ARGV
+  paths.each do |file|
     cookbook, type = metadata_walk(file)
     next if cookbook == false || changed_cookbooks.map(&:first).include?(cookbook) || file.include?('/test/')
 

--- a/bin/cookstyle-wrapper.rb
+++ b/bin/cookstyle-wrapper.rb
@@ -15,7 +15,7 @@ end
 
 # Exit early if there are no paths to lint
 success = true
-exit(success) if changed_cookbooks(bump_check: false).empty?
+exit(success) if changed_cookbooks(bump_check: false).compact.empty?
 
 # Install cookstyle and drop args that are paths
 system('bundle install >/dev/null') || exit(false)


### PR DESCRIPTION
Prevent batching of cookstyle hook and run against ruby files only by default.

Precommit-Verified: 99714e3a0a2bea5095997916b459669d720a68391ffe360ad316930fdf028937