### PR TITLE
comply with no verbose, dont bump check changed_cookbooks for cookstyle

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,6 @@
   language: script
   pass_filenames: true
   types: ['ruby']
-  verbose: true
 - id: rspec
   name: Unit test Ruby code with rspec
   description: Run rspec in changed paths with spec directories
@@ -13,7 +12,6 @@
   language: script
   pass_filenames: true
   types: ['ruby']
-  verbose: true
 - id: foodcritic
   name: Enforce Chef style guide with foodcritic
   description: Enforce Chef style guide with foodcritic
@@ -27,7 +25,6 @@
         .*/metadata\.rb
     )$
   exclude: .*/test/.*\.rb$
-  verbose: true
 - id: cookstyle
   name: Enforce Chef style guide with cookstyle
   description: Enforce Chef style guide with cookstyle
@@ -35,7 +32,6 @@
   language: script
   pass_filenames: true
   types: ['ruby']
-  verbose: true
   require_serial: true
 - id: chef-cookbook-version
   name: Ensure Chef cookbook version bump
@@ -44,4 +40,3 @@
   language: script
   pass_filenames: true
   types: ['file']
-  verbose: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To check Chef cookbook version bumps, use the `chef-cookbook-version` hook. Each
 To unit test Ruby changes in your repo, use the `rspec` hook. Each path in your repo with a `spec` directory should have a `Gemfile` that includes your desired version of rspec (or a derivative library). It will be installed via Bundler prior to testing. Rspec will only be run against the closest directory in a changed file's path with a spec dir.
 
     - repo: https://github.com/mattlqx/pre-commit-ruby
-      rev: v1.3.1
+      rev: v1.3.2
       hooks:
       - id: rubocop
       - id: foodcritic

--- a/bin/cookstyle-wrapper.rb
+++ b/bin/cookstyle-wrapper.rb
@@ -19,4 +19,4 @@ exit(success) if changed_cookbooks(bump_check: false).compact.empty?
 
 # Install cookstyle and drop args that are paths
 system('bundle install >/dev/null') || exit(false)
-system("bundle exec cookstyle --color #{fix} #{changed_cookbooks.map(&:first).join(' ')}") || exit(false)
+system("bundle exec cookstyle --color #{fix} #{changed_cookbooks(bump_check: false).map(&:first).join(' ')}")


### PR DESCRIPTION
- apparently, the decision was made to not allow hooks to specify verbose 🤷🏻‍♂️
- a small fix to prevent cookstyle from running against the whole repo

Precommit-Verified: e70cf8b4649e1590f80cfa7d637e8c4cfb2274a566175dad09e5171a48864773