### PR TITLE
Remove master reference from cookbook-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To check Chef cookbook version bumps, use the `chef-cookbook-version` hook. Each
 To unit test Ruby changes in your repo, use the `rspec` hook. Each path in your repo with a `spec` directory should have a `Gemfile` that includes your desired version of rspec (or a derivative library). It will be installed via Bundler prior to testing. Rspec will only be run against the closest directory in a changed file's path with a spec dir.
 
     - repo: https://github.com/mattlqx/pre-commit-ruby
-      rev: v1.3.2
+      rev: v1.3.3
       hooks:
       - id: rubocop
       - id: foodcritic

--- a/bin/cookbook-wrapper.rb
+++ b/bin/cookbook-wrapper.rb
@@ -14,7 +14,7 @@ end
 
 def file_from_git_history(path)
   prefix = path.start_with?('/') ? '' : './'
-  IO.popen("git show origin/master:#{prefix}#{path}", err: :close, &:read)
+  IO.popen("git show origin:#{prefix}#{path}", err: :close, &:read)
 end
 
 # Simple metadata.rb reader


### PR DESCRIPTION
Using origin/master here does not work when your main branch is called something else.  Switching to just plain origin appears to do the same.