### PR TITLE
Use Rubocop's flag to skip excluded files

### DIFF
--- a/bin/rubocop-wrapper.sh
+++ b/bin/rubocop-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 bundle install >/dev/null
-bundle exec rubocop --color "$@"
+bundle exec rubocop --force-exclusion --color "$@"


### PR DESCRIPTION
This flag been around since 2014 and version 0.20.0, and it avoids running rubocop against files that are excluded in the .rubocop.yml configuration.

    [1] https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#new-features-102